### PR TITLE
Fix inconsistent switch case syntax

### DIFF
--- a/src/VarRepresentation/Encoder.php
+++ b/src/VarRepresentation/Encoder.php
@@ -154,7 +154,7 @@ class Encoder
                         break;
                     case \T_STRING:
                         switch ($token[1]) {
-                            case 'NULL';
+                            case 'NULL':
                                 $values[] = 'null';
                             break 2;
                             /*


### PR DESCRIPTION
This must have been a typo, since it's the only case statement using the non-standard syntax.