### PR TITLE
Fix switch syntax deprecated in PHP 8.5

### DIFF
--- a/src/VarRepresentation/Encoder.php
+++ b/src/VarRepresentation/Encoder.php
@@ -154,7 +154,7 @@ class Encoder
                         break;
                     case \T_STRING:
                         switch ($token[1]) {
-                            case 'NULL';
+                            case 'NULL':
                                 $values[] = 'null';
                             break 2;
                             /*


### PR DESCRIPTION
Same as
https://github.com/TysonAndre/var_representation_polyfill/pull/5.

This was most certainly a typo, and the fix is now needed for PHP 8.5 support.